### PR TITLE
Avoid Warnings

### DIFF
--- a/lib/exquisite.ex
+++ b/lib/exquisite.ex
@@ -321,7 +321,7 @@ defmodule Exquisite do
 
   @function [ :is_atom, :is_float, :is_integer, :is_list, :is_number,
               :is_pid, :is_port, :is_reference, :is_tuple, :is_binary ]
-  defp internal({ name, _, [ref] } = whole, table, caller) when name in @function do
+  defp internal({ name, _, [ref] } = whole, table, _caller) when name in @function do
     if id = identify(ref, table) do
       { name, id }
     else
@@ -330,7 +330,7 @@ defmodule Exquisite do
   end
 
   # is_record(id, name)
-  defp internal({ :is_record, _, [ref, name] } = whole, table, caller) do
+  defp internal({ :is_record, _, [ref, name] } = whole, table, _caller) do
     if id = identify(ref, table) do
       { :is_record, id, name }
     else
@@ -339,7 +339,7 @@ defmodule Exquisite do
   end
 
   # is_record(id, name, size)
-  defp internal({ :is_record, _, [ref, name, size] } = whole, table, caller) do
+  defp internal({ :is_record, _, [ref, name, size] } = whole, table, _caller) do
     if id = identify(ref, table) do
       { :is_record, id, name, size }
     else
@@ -348,7 +348,7 @@ defmodule Exquisite do
   end
 
   # elem(id, index)
-  defp internal({ :elem, _, [ref, index] } = whole, table, caller) do
+  defp internal({ :elem, _, [ref, index] } = whole, table, _caller) do
     if id = identify(ref, table) do
       { :element, index + 1, id }
     else
@@ -357,7 +357,7 @@ defmodule Exquisite do
   end
 
   @function [ :abs, :hd, :length, :round, :tl, :trunc ]
-  defp internal({ name, _, [ref] } = whole, table, caller) when name in @function do
+  defp internal({ name, _, [ref] } = whole, table, _caller) when name in @function do
     if id = identify(ref, table) do
       { name, id }
     else
@@ -366,7 +366,7 @@ defmodule Exquisite do
   end
 
   # bnot foo
-  defp internal({ :bnot, _, [ref] } = whole, table, caller) do
+  defp internal({ :bnot, _, [ref] } = whole, table, _caller) do
     if id = identify(ref, table) do
       { :bnot, id }
     else
@@ -385,7 +385,7 @@ defmodule Exquisite do
   end
 
   # foo.bar
-  defp internal({{ :., _, _ }, _, _ } = whole, table, caller) do
+  defp internal({{ :., _, _ }, _, _ } = whole, table, _caller) do
     if id = identify(whole, table) do
       id
     else
@@ -404,7 +404,7 @@ defmodule Exquisite do
   end
 
   # foo
-  defp internal({ ref, _, _ } = whole, table, caller) do
+  defp internal({ ref, _, _ } = whole, table, _caller) do
     if id = identify(ref, table) do
       id
     else

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Exquisite.Mixfile do
   end
 
   defp deps do
-    [ { :ex_doc, "~> 0.14", only: [:dev] } ]
+    [ { :ex_doc, "~> 0.19", only: [:dev] } ]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,7 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
* Avoid warnings about unused variable `caller`.
* Update dev-dependency _ex\_doc_ to avoid compiler warnings.